### PR TITLE
[Enhancement] Adding pronto to dev dependency

### DIFF
--- a/safe_pusher.gemspec
+++ b/safe_pusher.gemspec
@@ -37,10 +37,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'colorize', '~> 0.8.1'
-  spec.add_dependency 'thor', '~> 0.20.0'
+  spec.add_dependency 'thor', '~> 0.19.4'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'fashion_police', '~> 1.2'
+  spec.add_development_dependency 'pronto', '~> 0.9.5'
   spec.add_development_dependency 'pry', '~> 0.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
- add pronto, pronto rubocop and pronto simplecov to dev dependency in order to use the command on self.